### PR TITLE
Updated ConversationMessage object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.3.1
+- Git tag fixed
+
 ## 1.3.0
 - The properties of the ConversationMessage object, returned by Conversations API functions `listMessages`, `readMessage` and `reply`, have now been aligned with the Message object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.3.0
+- The properties of the ConversationMessage object, returned by Conversations API functions `listMessages`, `readMessage` and `reply`, have now been aligned with the Message object
+
 ## 1.2.3
 - Check for response body in services
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Before running the tests, create a `keys.json` file in `test_resources/` with th
 **Please note**: when running the tests, your MessageBird account will be charged a small amount to test sending calls and messages.
 
 ## Acknowledgements
-This library was initially developer by [@lucvanderzandt](https://github.com/lucvanderzandt) while working at [@Drillster](https://github.com/Drillster). ❤️
+This library was initially developed by [@lucvanderzandt](https://github.com/lucvanderzandt) while working at [@Drillster](https://github.com/Drillster). ❤️
 
 ## License
 The MessageBird REST API for Dart is licensed under [The BSD 3-Clause License](http://opensource.org/licenses/BSD-3-Clause). Copyright (c) 2019, MessageBird B.V. 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dependencies:
   messagebird:
     git:
       url: https://github.com/messagebird/dart-rest-api.git
-      version: ^1.2.0
+      version: ^1.3.0
 ```
 
 ## Usage

--- a/lib/src/conversations/api_conversations_service.dart
+++ b/lib/src/conversations/api_conversations_service.dart
@@ -63,12 +63,13 @@ class ApiConversationsService extends BaseService
               : ConversationMessage.fromJson(response.body)));
 
   @override
-  Future<Message> reply(String id, Message message) =>
+  Future<ConversationMessage> reply(String id, Message message) =>
       post('/conversations/$id/messages',
               hostname: BaseService.conversationsEndpoint,
               body: message.toMap())
-          .then((response) => Future.value(
-              response?.body == null ? null : Message.fromJson(response.body)));
+          .then((response) => Future.value(response?.body == null
+              ? null
+              : ConversationMessage.fromJson(response.body)));
 
   @override
   Future<MessageResponse> send(ConversationMessage message) => post('/send',

--- a/lib/src/conversations/conversations_service.dart
+++ b/lib/src/conversations/conversations_service.dart
@@ -22,14 +22,13 @@ abstract class ConversationsService {
       {int limit, int offset, List<String> ids, ConversationStatus status});
 
   /// Retrieve all the messages from the conversation with the provided [id].
-  Future<List<ConversationMessage>> listMessages(String id,
-      {int limit, int offset});
+  Future<List<Message>> listMessages(String id, {int limit, int offset});
 
   /// Retrieve a single conversation.
   Future<Conversation> read(String id);
 
   /// View a message.
-  Future<ConversationMessage> readMessage(String id);
+  Future<Message> readMessage(String id);
 
   /// Add a new message to an existing conversation and sends it to the
   /// contact that you're in conversation with.

--- a/lib/src/conversations/model/conversation_message.dart
+++ b/lib/src/conversations/model/conversation_message.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:messagebird/src/util.dart';
+
 import '../../general/model/content.dart';
 import '../../general/model/message.dart';
 
@@ -20,21 +22,35 @@ class ConversationMessage extends Message {
 
   /// Constructor.
   const ConversationMessage(
-      {MessageType type,
-      Content content,
+      {String id,
+      String conversationId,
+      String channelId,
+      String platform,
       String to,
       String from,
-      String channelId,
+      MessageDirection direction,
+      MessageStatus status,
+      MessageType type,
+      Content content,
+      DateTime createdDatetime,
+      DateTime updatedDatetime,
       Map<String, dynamic> source,
       this.reportUrl,
       this.eventType,
       this.fallback})
       : super(
-            type: type,
-            content: content,
+            id: id,
+            conversationId: conversationId,
+            channelId: channelId,
+            platform: platform,
             to: to,
             from: from,
-            channelId: channelId,
+            direction: direction,
+            status: status,
+            type: type,
+            content: content,
+            createdDatetime: createdDatetime,
+            updatedDatetime: updatedDatetime,
             source: source);
 
   /// Construct a [ConversationMessage] object from a json [String].
@@ -52,13 +68,27 @@ class ConversationMessage extends Message {
     return map == null
         ? null
         : ConversationMessage(
+            id: map['id'],
+            conversationId: map['conversationId'],
+            channelId: map['channelId'],
+            platform: map['platform'],
+            from: map['from'],
+            to: map['to'],
+            direction: MessageDirection.values.firstWhere(
+                (direction) =>
+                    direction.toString() ==
+                    'MessageDirection.${map['direction']}',
+                orElse: () => null),
+            status: MessageStatus.values.firstWhere(
+                (status) =>
+                    status.toString() == 'MessageStatus.${map['status']}',
+                orElse: () => null),
             type: type,
             content: map['content'] == null
                 ? null
                 : Content.fromMap(type, map['content']),
-            from: map['from'],
-            to: map['to'],
-            channelId: map['channelId'],
+            createdDatetime: parseDate(map['createdDatetime']),
+            updatedDatetime: parseDate(map['updatedDatetime']),
             source: map['source'],
             reportUrl: map['reportUrl'],
             eventType: map['eventType'],
@@ -74,11 +104,18 @@ class ConversationMessage extends Message {
   /// Get a json object representing the [ConversationMessage]
   @override
   Map<String, dynamic> toMap() => {
-        'type': type?.toString()?.replaceAll('MessageType.', ''),
-        'content': content?.toMap(),
-        'from': from,
-        'to': to,
+        'id': id,
+        'conversationId': conversationId,
         'channelId': channelId,
+        'platform': platform,
+        'to': to,
+        'from': from,
+        'direction': direction?.toString()?.replaceAll('MessageDirection.', ''),
+        'status': status?.toString()?.replaceAll('MessageStatus.', ''),
+        'type': type?.toString()?.replaceAll('MessageType.', ''),
+        'content': content.toMap(),
+        'createdDatetime': createdDatetime?.toString(),
+        'updatedDatetime': updatedDatetime?.toString(),
         'source': source,
         'reportUrl': reportUrl,
         'eventType': eventType,

--- a/lib/src/general/model/content.dart
+++ b/lib/src/general/model/content.dart
@@ -13,7 +13,7 @@ class AudioContent extends Content {
   const AudioContent(this.audio);
 
   @override
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   @override
   Map<String, dynamic> toMap() => {'audio': audio.toMap()};
@@ -91,7 +91,7 @@ class Currency {
         );
 
   /// Get a json [String] representing the [Currency] object.
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   /// Convert this object to a [Map].
   Map<String, dynamic> toMap() => {
@@ -109,7 +109,7 @@ class FileContent extends Content {
   const FileContent(this.file);
 
   @override
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   @override
   Map<String, dynamic> toMap() => {'file': file.toMap()};
@@ -160,7 +160,7 @@ class HSMContent extends Content {
                   (parameter) => HSMLocalizableParameters.fromMap(parameter))));
 
   @override
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   @override
   Map<String, dynamic> toMap() => {
@@ -206,7 +206,7 @@ class HSMLanguage {
         );
 
   /// Get a json [String] representing the [HSMLanguage].
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   /// Convert this object to a [Map].
   Map<String, dynamic> toMap() => {
@@ -289,7 +289,7 @@ class ImageContent extends Content {
   const ImageContent(this.image);
 
   @override
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   @override
   Map<String, dynamic> toMap() => {'image': image.toMap()};
@@ -324,7 +324,7 @@ class Location {
         );
 
   /// Get a json [String] representing the [Location].
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   /// Convert this object to a [Map]
   Map<String, dynamic> toMap() => {
@@ -342,7 +342,7 @@ class LocationContent extends Content {
   const LocationContent(this.location);
 
   @override
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   @override
   Map<String, dynamic> toMap() => {'location': location.toMap()};
@@ -377,7 +377,7 @@ class Media {
         );
 
   /// Get a json [String] representing the [Media].
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   /// Convert this object to a [Map].
   Map<String, dynamic> toMap() => {
@@ -395,7 +395,7 @@ class TextContent extends Content {
   const TextContent(this.text);
 
   @override
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   @override
   Map<String, dynamic> toMap() => {'text': text};
@@ -410,7 +410,7 @@ class VideoContent extends Content {
   const VideoContent(this.video);
 
   @override
-  String toJson() => json.encode(toMap);
+  String toJson() => json.encode(toMap());
 
   @override
   Map<String, dynamic> toMap() => {'video': video.toMap()};

--- a/lib/src/general/model/message.dart
+++ b/lib/src/general/model/message.dart
@@ -100,12 +100,11 @@ class Message {
             direction: MessageDirection.values.firstWhere(
                 (direction) =>
                     direction.toString() ==
-                    'MessageDirection.${map['direction'].toString()}',
+                    'MessageDirection.${map['direction']}',
                 orElse: () => null),
             status: MessageStatus.values.firstWhere(
                 (status) =>
-                    status.toString() ==
-                    'MessageStatus.${map['status'].toString()}',
+                    status.toString() == 'MessageStatus.${map['status']}',
                 orElse: () => null),
             type: type,
             content: Content.fromMap(type, map['content']),
@@ -126,6 +125,7 @@ class Message {
         'to': to,
         'from': from,
         'direction': direction?.toString()?.replaceAll('MessageDirection.', ''),
+        'status': status?.toString()?.replaceAll('MessageStatus.', ''),
         'type': type?.toString()?.replaceAll('MessageType.', ''),
         'content': content.toMap(),
         'createdDatetime': createdDatetime?.toString(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messagebird
-version: 1.3.0
+version: 1.3.1
 description: This repository provides a Dart client for MessageBird's REST API.
 homepage: https://github.com/messagebird/dart-rest-api
 repository: https://github.com/messagebird/dart-rest-api.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messagebird
-version: 1.2.3
+version: 1.3.0
 description: This repository provides a Dart client for MessageBird's REST API.
 homepage: https://github.com/messagebird/dart-rest-api
 repository: https://github.com/messagebird/dart-rest-api.git


### PR DESCRIPTION
In the initially developed library, I didn't extend the `ConversationMessage` object from the `Message` object, which caused some problems while trying to read out the properties of a message. This release fixes this.

Also, a heads up, do tag your releases (using `git tag -a {version}`), as the installation procedure as described in the README requires so.